### PR TITLE
Develop

### DIFF
--- a/minilog.c
+++ b/minilog.c
@@ -50,11 +50,10 @@ int  minilog_setup(struct  __minilog_initial_param_t * __Nullable  miniparm ) {
 
   if(miniparm)
   {
-    fdstream = __configure(miniparm) ; 
-    if (!(~0 ^ fdstream))  
-      LOGWARN("minilog startup configuration failed") ;  
+     minilog_configure(miniparm) ; 
   }
-  
+
+  /*No buffering  on standard output   */
   (void) setvbuf(stdout ,  (char *) 0 ,  _IONBF , 0 ) ;  
   
   if(minilog_set_current_locale()) 
@@ -72,59 +71,57 @@ int  minilog_setup(struct  __minilog_initial_param_t * __Nullable  miniparm ) {
 }
 
 
-int  __configure(struct __minilog_initial_param_t *  restrict parm )  
+int minilog_configure(struct __minilog_initial_param_t *  restrict parm )  
 {
-   if (!parm) return ~0 ;  
    
    /* handle stream record file*/ 
-   if (!parm->_record) 
-     return 0;
-
-   
-
-   /*TODO : How to synchronize io terminal and file stream log*/ 
-   /*PISTE: faire un fifo  temporaire  qui va televerser 
-    *           sur un ficher de log  et le terminal*/ 
-   
-   /*! Add Extension .fifo*/ 
-   char logqueuing[0x14] = {0}; 
-   memcpy(logqueuing , parm->_record , strlen(parm->_record )) ;  
-   strcat(logqueuing ,   ".fifo") ;  
-
-   if (!(~0 ^(mkfifo(logqueuing , S_IRUSR |  S_IWUSR)))  )
-   {  
-     if(!(EEXIST ^ errno)) 
-       LOGWARN("creating temporary fifo file :%s \n",  strerror(*__errno_location())) ;   
-   }
-
-   int fd_streamrec =  open(logqueuing , O_RDWR)  ; 
-  
-   if (!(~0  ^ fd_streamrec))
+   if (parm->_fstream->_record_file) 
    {
-     LOGWARN("No able to open  file object, No binding : %s ", strerror(*__errno_location())) ;  
-     return ~0 ; 
+     int link_fds = minilog_create_record_stream_pipeline(parm->_fstream);
+     minilog_watchlog(link_fds);
    }
 
-
-   /*! Add color to  log  file  but hard  to read
-    *  Not recommanded if you  want to analyse the log file later on 
-    * dup2(fd_streamrec , STDOUT_FILENO) ; 
-    */
-
-   dup2(fd_streamrec , STDERR_FILENO); 
-
-   /*! TODO : Should provide a flags that enable synchronisation  between file and terminal*/ 
-  
-   /* The watchlog  create a subprocess  that listen  on logfile
-    * to showup  on terminal*/ 
-    watchlog(fd_streamrec  , parm->_record) ;  
-   
-   return  fd_streamrec ; 
+   return  0 ; 
    
 }
 
+int  minilog_create_record_stream_pipeline(mr_sync * restrict  source )
+{
+  if(!source ) return  -EDESTADDRREQ ;
+  
+  char template[0x64]  = {0} ; 
+  strcat(template ,  source->_record_file) ; 
+  strcat(template  , "XXXXXX") ;  
+  source->_stream_pipe = mktemp(template) ;  
+  
+  if(!source->_stream_pipe)  
+    return errno ; 
+  
+  if(!(~0 ^  mkfifo(source->_stream_pipe , S_IRUSR  | S_IWUSR))) 
+  {
+     if((EEXIST ^ errno))
+       return errno ; 
+  }
+   
+  
+  source->_fd_stream_links  = (open(source->_stream_pipe , O_RDWR) << 8) ;  
+  source->_fd_stream_links |= open(source->_record_file , O_CREAT|O_RDWR , S_IRUSR|S_IWUSR) ;
+  
 
-void watchlog(int fd  ,  const char * restrict   recordfile ) 
+  if(!(~0  ^ ((source->_fd_stream_links >> 8) & 0xff))) 
+  { 
+    if (~0 != (source->_fd_stream_links  & 0xff))   
+      close(source->_fd_stream_links &0xff ) ; 
+
+    unlink(source->_stream_pipe) ; 
+    return  -EACCES ;
+  } 
+  
+  dup2((source->_fd_stream_links >> 8) , STDERR_FILENO) ; 
+  return source->_fd_stream_links ; 
+}
+
+void minilog_watchlog(int fds) 
 {
    pid_t logspy =  fork() ; 
    if(!(~0 ^ logspy))
@@ -135,29 +132,24 @@ void watchlog(int fd  ,  const char * restrict   recordfile )
   
    if(!(logspy & 0xffff))
    {
-      //tail_forward_sync(fd ,recordfile)  ; 
-      tail_forward(fd , recordfile ) ; /* like tail -f command */
+      minilog_tail_forward_sync(fds)  ; /* like tail -f command */
    }
-
 
 }
 
-static void tail_forward(int fd  ,  const char * restrict recordfile ) 
+static void minilog_tail_forward_sync(int fds)  
 {
 
   struct  pollfd  evtpolling = { 
-    .fd = fd ,
+    .fd =  ((fds >> 8) & 0xff)  ,
     .events=POLLIN, 
     .revents= 0 , 
   };
+
+  int rfd =  (fds  & 0xff) ; 
  
-  int rfd =  open(recordfile ,  O_CREAT|O_WRONLY| O_APPEND , S_IRUSR | S_IWUSR) ; 
-  if(! (~0 ^ rfd)) 
-  {
-     LOGWARN("Not able to synchronise to :%s", recordfile) ; 
-  }
   printf("-> start listening on   child proc : %i \n", getpid());  
-  char minilog_buffer_sync[10000] = {0} ; 
+  char minilog_buffer_sync[MIBLMT] = {0} ; 
   while(1) 
   {
      int pollingstsatus =  poll(&evtpolling , 1 , ~0)  ; 
@@ -171,7 +163,7 @@ static void tail_forward(int fd  ,  const char * restrict recordfile )
        read(evtpolling.fd,minilog_buffer_sync , 10000) ;
       
        fprintf(stdout , "%s" , minilog_buffer_sync) ; 
-       write(rfd , minilog_buffer_sync , strlen(minilog_buffer_sync)) ;  
+       write(rfd , minilog_buffer_sync  , strlen(minilog_buffer_sync)) ;  
        bzero(minilog_buffer_sync , 10000) ; 
        evtpolling.revents &=~POLLIN ;  
      }else 

--- a/minilog.h
+++ b/minilog.h
@@ -135,14 +135,22 @@ extern int fdstream  ;
 #define MINILOG_ABORT_ON_FATALITY 1  
 #endif
 
-
 #define  STREAM_ON(__fstream)\
-  &(struct __minilog_initial_param_t){ ._record = __fstream} 
+  &(struct __minilog_initial_param_t)\
+  {\
+    ._fstream =&(struct __minilog_record_sync){ ._record_file =__fstream}\
+  }
+
+typedef struct   __minilog_record_sync mr_sync ; 
+struct __minilog_record_sync   { 
+  char * _record_file;            /* The target record file */ 
+  char * _stream_pipe;            /* Stream pipe that listen on stderr or stdout  */
+  int  _fd_stream_links ;         /* file descriptors for record  file  and streampipe */
+};   
 
 typedef struct   __minilog_initial_param_t mparm ; 
 struct __minilog_initial_param_t { 
-  char *_record ;  /* filename */
-  int   _options;  /* bit mask */
+   struct __minilog_record_sync *  _fstream; 
 }; 
 
 
@@ -151,15 +159,11 @@ struct __minilog_initial_param_t {
  * @brief configure or initilize the terminal capbilities  
  */
 __mlog int minilog_setup(struct __minilog_initial_param_t * __Nullable __initial_parameters) ; 
-
 static  void minilog_cleanup(void) __attribute__((destructor)) ; 
-
-int  __configure(struct __minilog_initial_param_t * __restrict__  __parm)  ; 
-
-
-void  watchlog(int __fd , const char * __restrict__  __record_fn) ;
-
-static void tail_forward(int __fd , const char * __restrict__  __record_fn ) ; 
+int  minilog_configure(struct __minilog_initial_param_t * __restrict__  __parm)  ; 
+int  minilog_create_record_stream_pipeline(mr_sync * __restrict__  __source); 
+void  minilog_watchlog(int __fds) ;
+static void minilog_tail_forward_sync(int __fds ) ; 
 
 /* @fn minilog_set_current_locale(void) 
  * @brief apply  current locale  (l18n & l10n) for portability 

--- a/minilog.h
+++ b/minilog.h
@@ -153,16 +153,24 @@ struct __minilog_initial_param_t {
    struct __minilog_record_sync *  _fstream; 
 }; 
 
+typedef  void (*multi_sigcatch)(int  , ...) ;
 
+#define  DEFAULT_TARGET_SIGNALS  3,SIGINT,SIGCHLD,SIGTERM 
+#define  MLOG_DEFSIGCATCH(__nsigs , ...) \
+  sigcatcher(__nsigs , ##__VA_ARGS__) 
 
 /* @fn minilog_setup(void) ; 
  * @brief configure or initilize the terminal capbilities  
  */
 __mlog int minilog_setup(struct __minilog_initial_param_t * __Nullable __initial_parameters) ; 
-static  void minilog_cleanup(void) __attribute__((destructor)) ; 
+void minilog_cleanup(void) __attribute__((destructor));  
 int  minilog_configure(struct __minilog_initial_param_t * __restrict__  __parm)  ; 
 int  minilog_create_record_stream_pipeline(mr_sync * __restrict__  __source); 
-void  minilog_watchlog(int __fds) ;
+void  minilog_watchlog(int __fds , multi_sigcatch __variadic_signal_hanler_callback);
+
+void  sigcatcher(const int __nsigs ,  ...) __attribute__((weak)) ; 
+void  minilog_defsighdl(int __target_signal) __attribute__((weak)) ; 
+
 static void minilog_tail_forward_sync(int __fds ) ; 
 
 /* @fn minilog_set_current_locale(void) 


### PR DESCRIPTION
[Tweak configuration for direct recording logs in file](https://github.com/Galsen-Low-Level/Minilog/commit/47f992fc4ea49f1b8c142f62dce952af7f4ee660) 

Making  a lot of changes in how  the configuration manage to
handle  2 files by creating a temprorary  namedpipe to listen
when new data are available and ready to write on targeted stream
file.
Signed-off-by : Umar Ba <jUmarB@protonmail.com>

[Handling ressources specialy when for log file](https://github.com/Galsen-Low-Level/Minilog/commit/316108a3b960ab9007a7a07449e78767d874da03) 

Dealing with signals  to know when the process watchlog stop
and releases the allocated ressources  for better memory management.
Provide variadic function to specify multiple signal to deal with,
and mark them as weak , So the user can  override this function and
try to implement his own logic for more flexibility.



@[Jukoo](https://github.com/Galsen-Low-Level/Minilog/commits?author=Jukoo)
